### PR TITLE
Update to TestNG 6.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ allprojects{
     apply plugin: 'eclipse'
     apply plugin: 'jacoco'
     apply plugin: 'nebula.dependency-recommender'
+    apply plugin: 'org.starchartlabs.flare.dependency-insight'
 
     dependencyRecommendations {
         dependencyLock file: file("$rootDir/dependencies.lock")

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -21,5 +21,5 @@
 	"org.testfx:testfx-core" : { "locked": "4.0.6-alpha" },
 	"org.testfx:testfx-junit" : { "locked": "4.0.6-alpha" },
 	
-	"org.testng:testng": { "locked": "6.9.10" },
+	"org.testng:testng": { "locked": "6.11" },
 }


### PR DESCRIPTION
TestNG 6.9.10, our current version, has an optional transitive dependency on BeanShell, marked by CoPilot as a security risk.

TestNG 6.11 changes to an apache version of this project which has been updated